### PR TITLE
feat: autostart systemd user session for user running code-server

### DIFF
--- a/tevbox.sh
+++ b/tevbox.sh
@@ -18,7 +18,8 @@ systemctl mask ssh
 
 ### User
 useradd ${username} -m -s /usr/bin/bash -G sudo -p ${password}
-echo "${username} ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers 
+echo "${username} ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers
+loginctl enable-linger ${username} # used to autostart the systemd/user session that reads env vars for code-server
 
 ### Caddy
 caddy add-package github.com/caddy-dns/hetzner 


### PR DESCRIPTION
This fixes the problem where code-server isn't aware of environment variables set in the ~/.config/environment.d directory since using code-server doesn't mean you login to the PAM env.